### PR TITLE
Added characters to the german keyboard (i.e. "é" for words like "Café")

### DIFF
--- a/java/res/values-de/donottranslate-more-keys.xml
+++ b/java/res/values-de/donottranslate-more-keys.xml
@@ -19,7 +19,8 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="more_keys_for_a">ä,â,à,á,æ,ã,å,ā</string>
-    <string name="more_keys_for_e">3,ė</string>
+    <string name="more_keys_for_e">3,ê,è,é,ė,ë,ē</string>
+    <string name="more_keys_for_i">8,î,ï,í,ī,ì</string>
     <string name="more_keys_for_o">9,ö,ô,ò,ó,õ,œ,ø,ō</string>
     <string name="more_keys_for_u">7,ü,û,ù,ú,ū</string>
     <string name="more_keys_for_s">ß,ś,š</string>


### PR DESCRIPTION
Some characters are missing in the german keyboard Layout in almost any ROM, from official over Cyanogen to Gummy.

Reason is unknown to me, in the english keyboard they are available. (é, è, ê ...)
Quite commonly used in Germany as well (Café for example).

Fix was also applied to AOKP ROm and has no side effects.
